### PR TITLE
Close modal and drawers on company approval or rejection

### DIFF
--- a/src/components/DrawerVacante/DrawerLinkerVacancies.tsx
+++ b/src/components/DrawerVacante/DrawerLinkerVacancies.tsx
@@ -16,14 +16,14 @@ import { useState, useRef, useEffect } from 'react';
 import { useApplicantStore } from '@/app/store/authApplicantStore';
 import { apiService } from '@/services/api.service';
 import { toast } from 'sonner';
-import { createPortal } from 'react-dom'; 
+import { createPortal } from 'react-dom';
 
 interface DrawerLinkerVacanciesProps {
   job: JobCardProps;
   sideDrawer: 'right' | 'left';
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
-  onSuccess?: () => void; 
+  onSuccess?: () => void;
 }
 
 export default function DrawerLinkerVacancies({
@@ -33,7 +33,7 @@ export default function DrawerLinkerVacancies({
   onOpenChange,
   onSuccess
 }: DrawerLinkerVacanciesProps) {
-  
+
   const { id: linkerId } = useApplicantStore();
 
   const [mounted, setMounted] = useState(false);
@@ -80,10 +80,10 @@ export default function DrawerLinkerVacancies({
 
     try {
       const endpoint = `/linkers/${linkerId}/vacancies/${job.id}`;
-      
+
       const body = {
         validation,
-        ...(comment && { comment }) 
+        ...(comment && { comment })
       };
 
       const response = await apiService.patch(endpoint, body);
@@ -93,7 +93,7 @@ export default function DrawerLinkerVacancies({
       }
 
       toast.success(validation ? 'Vacante aprobada correctamente.' : 'Vacante rechazada correctamente.');
-      
+
       setShowAllowVacancy(false);
       setShowRejectVacancy(false);
 
@@ -110,16 +110,16 @@ export default function DrawerLinkerVacancies({
   };
 
   const handleAllowConfirm = () => {
-    handleReviewVacancy(true); 
+    handleReviewVacancy(true);
   };
 
   const handleRejectConfirm = (data: { reason: string }) => {
-    handleReviewVacancy(false, data.reason); 
+    handleReviewVacancy(false, data.reason);
   };
 
   const displayAgeRange = () => {
     if (!job.ageRange || (job.ageRange.min === 0 && job.ageRange.max === 0)) {
-        return 'No especificado';
+      return 'No especificado';
     }
     return `${job.ageRange.min} - ${job.ageRange.max} años`;
   };
@@ -142,10 +142,17 @@ export default function DrawerLinkerVacancies({
               </DrawerTitle>
 
               <div className="flex flex-row gap-4">
-                <Button variant="primary" color="danger" className="px-6" onClick={() => setShowRejectVacancy(true)}>
+                <Button variant="primary" color="danger" className="px-6" onClick={() => {
+                  setShowRejectVacancy(true);
+                  setOpen(false)
+                }
+                }>
                   Rechazar
                 </Button>
-                <Button variant="primary" color="success" className="px-6" onClick={() => setShowAllowVacancy(true)}>
+                <Button variant="primary" color="success" className="px-6" onClick={() => {
+                  setShowAllowVacancy(true)
+                  setOpen(false)
+                }}>
                   Aprobar
                 </Button>
               </div>
@@ -153,7 +160,7 @@ export default function DrawerLinkerVacancies({
           </DrawerHeader>
 
           <div className="w-10/12 bg-white justify-center mx-auto my-5 shadow-md border border-gray-200 rounded-lg">
-            
+
             <div className="px-10 py-6 flex justify-between">
               <h3 className="text-base font-medium w-1/3">Descripción</h3>
               <div className="w-2/3">
@@ -243,14 +250,14 @@ export default function DrawerLinkerVacancies({
         </DrawerContent>
       </Drawer>
 
-      
-      
+
+
       {mounted && showAllowVacancy && createPortal(
         <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50">
-          <AllowVacancyModal 
-            open={true} 
-            onConfirm={handleAllowConfirm} 
-            onClose={closeAllow} 
+          <AllowVacancyModal
+            open={true}
+            onConfirm={handleAllowConfirm}
+            onClose={closeAllow}
           />
         </div>,
         document.body
@@ -258,12 +265,12 @@ export default function DrawerLinkerVacancies({
 
       {mounted && showRejectVacancy && createPortal(
         <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50">
-          <RejectVacancyModal 
+          <RejectVacancyModal
             open={true}
-            companyName={job.company} 
-            roleTitle={job.title}    
-            onConfirm={handleRejectConfirm} 
-            onClose={closeReject} 
+            companyName={job.company}
+            roleTitle={job.title}
+            onConfirm={handleRejectConfirm}
+            onClose={closeReject}
           />
         </div>,
         document.body

--- a/src/components/linker/DrawerLinkerUser.tsx
+++ b/src/components/linker/DrawerLinkerUser.tsx
@@ -26,7 +26,7 @@ interface DrawerLinkerUserProps {
   sideDrawer: 'right' | 'left';
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
-  onSuccess?: () => void; 
+  onSuccess?: () => void;
 }
 
 export default function DrawerLinkerUser({
@@ -37,7 +37,7 @@ export default function DrawerLinkerUser({
   onSuccess
 }: DrawerLinkerUserProps) {
   const { id: linkerId, token } = useApplicantStore();
-  
+
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
 
@@ -76,7 +76,7 @@ export default function DrawerLinkerUser({
     setIsSubmitting(true);
     try {
       const endpoint = `/linkers/${linkerId}/users/${user.id}`;
-      
+
       const body = {
         validation,
         comment: validation ? null : (comment || "Información incompleta o incorrecta")
@@ -89,13 +89,13 @@ export default function DrawerLinkerUser({
       }
 
       toast.success(validation ? 'Usuario aprobado correctamente.' : 'Usuario rechazado correctamente.');
-      
+
       setShowAllowUser(false);
       setShowRejectUser(false);
       setOpen(false);
 
       if (onSuccess) {
-        onSuccess(); 
+        onSuccess();
       }
     } catch (error) {
       console.error(error);
@@ -131,17 +131,23 @@ export default function DrawerLinkerUser({
               </div>
 
               <div className="flex flex-row gap-4 shrink-0 items-center">
-                <Button 
+                <Button
                   variant="primary" color="danger" className="px-6"
                   disabled={isSubmitting}
-                  onClick={() => setShowRejectUser(true)}
+                  onClick={() => {
+                    setShowRejectUser(true)
+                    setOpen(false)
+                  }}
                 >
                   Rechazar
                 </Button>
-                <Button 
+                <Button
                   variant="primary" color="success" className="px-6"
                   disabled={isSubmitting}
-                  onClick={() => setShowAllowUser(true)}
+                  onClick={() => {
+                    setShowAllowUser(true)
+                    setOpen(false)
+                  }}
                 >
                   Aprobar
                 </Button>
@@ -222,8 +228,8 @@ export default function DrawerLinkerUser({
             </div>
           </div>
 
-          <DrawerClose 
-            className="text-base font-bold hover:bg-zinc-200 border-0 text-red-500 px-4 py-3 rounded-md mx-auto mb-7 cursor-pointer" 
+          <DrawerClose
+            className="text-base font-bold hover:bg-zinc-200 border-0 text-red-500 px-4 py-3 rounded-md mx-auto mb-7 cursor-pointer"
             onClick={() => setOpen(false)}
           >
             Cancelar
@@ -234,7 +240,7 @@ export default function DrawerLinkerUser({
       {/* Portales para Modales de Acción */}
       {mounted && showAllowUser && createPortal(
         <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm">
-          <AllowUserModal 
+          <AllowUserModal
             open={true}
             onClose={() => setShowAllowUser(false)}
             onConfirm={handleAllowConfirm}
@@ -245,7 +251,7 @@ export default function DrawerLinkerUser({
 
       {mounted && showRejectUser && createPortal(
         <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm">
-          <RejectUserModal 
+          <RejectUserModal
             open={true}
             userName={candidateName}
             email={user.email}


### PR DESCRIPTION
Esta PR actualiza el comportamiento de los botones de aprobación y rechazo en los componentes `DrawerLinkerVacancies` y `DrawerLinkerUser`. Ahora, cuando un usuario hace clic en "Rechazar" o "Aprobar", se muestra la ventana modal correspondiente y el cajón se cierra automáticamente, lo que mejora la experiencia del usuario al reducir los clics adicionales.

**Mejoras en la interacción del usuario:**

* Se actualizaron los controladores de los botones "Rechazar" y "Aprobar" en `DrawerLinkerVacancies` para que muestren la ventana modal correspondiente y cierren el cajón al hacer clic.

* Se actualizaron los controladores de los botones "Rechazar" y "Aprobar" en `DrawerLinkerUser` para que muestren la ventana modal correspondiente y cierren el cajón al hacer clic.